### PR TITLE
Add Gob serializer

### DIFF
--- a/handler/taskor.go
+++ b/handler/taskor.go
@@ -51,8 +51,12 @@ type Taskor struct {
 
 // New create a new Taskor instance
 func New(runner runner.Runner) (*Taskor, error) {
+	return NewWithSerializer(runner, serializer.TypeJSON)
+}
+
+func NewWithSerializer(runner runner.Runner, serializerType serializer.Type) (*Taskor, error) {
 	// Init serializer
-	serializer.GlobalSerializer = serializer.TypeJSON
+	serializer.GlobalSerializer = serializerType
 
 	var t Taskor
 	// Init task runner

--- a/runner/amqp/publisher.go
+++ b/runner/amqp/publisher.go
@@ -28,7 +28,7 @@ func (t *RunnerAmqp) Send(task *task.Task) error {
 		false,       // mandatory
 		false,       // immediate
 		amqp.Publishing{
-			ContentType: "text/plain",
+			ContentType: serializer.GetContentType(t.serializer),
 			Body:        body,
 		})
 	if err != nil {

--- a/serializer/gob.go
+++ b/serializer/gob.go
@@ -1,0 +1,27 @@
+package serializer
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+)
+
+type serializerGob struct{}
+
+func (s *serializerGob) Serialize(data interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode with gob: %v", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func (s *serializerGob) Unserialize(v interface{}, data []byte) error {
+	buf := bytes.NewReader(data)
+	err := gob.NewDecoder(buf).Decode(v)
+	if err != nil {
+		return fmt.Errorf("failed to decode with gob: %v", err)
+	}
+	return nil
+}

--- a/serializer/gob_test.go
+++ b/serializer/gob_test.go
@@ -1,0 +1,117 @@
+package serializer
+
+import (
+	"encoding/gob"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type TestInterface interface {
+	dummy()
+}
+
+type TestInterfaceImpl1 struct {
+	S string
+}
+
+func (t TestInterfaceImpl1) dummy() {}
+
+type TestInterfaceImpl2 struct {
+	I int
+}
+
+func (t TestInterfaceImpl2) dummy() {}
+
+type TestStruct struct {
+	I int
+	S string
+	A []string
+	T TestInterface
+	P *string
+}
+
+func Test_serializerGob(t *testing.T) {
+	for _, concreteType := range []any{TestInterfaceImpl1{}, TestInterfaceImpl2{}} {
+		gob.Register(concreteType)
+	}
+
+	testString := "hello"
+
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "without any attributes set",
+			data: TestStruct{},
+		},
+		{
+			name: "with some attributes with scalar type set",
+			data: TestStruct{
+				I: 1,
+			},
+		},
+		{
+			name: "with some attributes with scalar type set",
+			data: TestStruct{
+				S: "hello",
+			},
+		},
+		{
+			name: "with some attributes with array type set",
+			data: TestStruct{
+				A: []string{"hello", "world"},
+			},
+		},
+		{
+			name: "with some attributes with interface type set",
+			data: TestStruct{
+				T: TestInterfaceImpl1{
+					S: "hello",
+				},
+			},
+		},
+		{
+			name: "with some attributes with interface type set",
+			data: TestStruct{
+				T: TestInterfaceImpl2{
+					I: 1,
+				},
+			},
+		},
+		{
+			name: "with some attributes with pointer type set",
+			data: TestStruct{
+				P: &testString,
+			},
+		},
+		{
+			name: "with all attributes set",
+			data: TestStruct{
+				I: 1,
+				S: "hello",
+				A: []string{"hello", "world"},
+				T: TestInterfaceImpl1{
+					S: "hello",
+				},
+				P: &testString,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serializer := &serializerGob{}
+
+			serialized, err := serializer.Serialize(tt.data)
+			require.NoError(t, err)
+
+			var unserialized TestStruct
+			err = serializer.Unserialize(&unserialized, serialized)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.data, unserialized)
+		})
+	}
+}

--- a/serializer/serializer.go
+++ b/serializer/serializer.go
@@ -6,6 +6,7 @@ type Type int
 // Serializer constant
 const (
 	TypeJSON Type = 1 + iota
+	TypeGob
 )
 
 // GlobalSerializer var use to choose Serializer, should be init
@@ -19,14 +20,7 @@ type Serializer interface {
 
 // GetGlobalSerializer Return serilizer from type
 func GetGlobalSerializer() Serializer {
-	var serial Serializer
-	switch {
-	case GlobalSerializer == TypeJSON:
-		serial = &serializerJSON{}
-	default:
-		serial = &serializerJSON{}
-	}
-	return serial
+	return GetSerializer(GlobalSerializer)
 }
 
 // GetSerializer Return serilizer from type
@@ -35,8 +29,21 @@ func GetSerializer(Type Type) Serializer {
 	switch {
 	case Type == TypeJSON:
 		serial = &serializerJSON{}
+	case Type == TypeGob:
+		serial = &serializerGob{}
 	default:
 		serial = &serializerJSON{}
 	}
 	return serial
+}
+
+func GetContentType(Type Type) string {
+	switch {
+	case Type == TypeJSON:
+		return "text/plain"
+	case Type == TypeGob:
+		return "application/octet-stream"
+	default:
+		return "text/plain"
+	}
 }

--- a/task/task.go
+++ b/task/task.go
@@ -173,8 +173,12 @@ func (t Task) LoggerFields() map[string]interface{} {
 
 // CreateTask create a new task without running it
 func CreateTask(taskName string, param interface{}) (*Task, error) {
+	return CreateTaskWithSerializer(taskName, param, serializer.GlobalSerializer)
+}
+
+func CreateTaskWithSerializer(taskName string, param interface{}, serializerType serializer.Type) (*Task, error) {
 	// Serialize parameter
-	serializedParameter, err := serializer.GetGlobalSerializer().Serialize(param)
+	serializedParameter, err := serializer.GetSerializer(serializerType).Serialize(param)
 	if err != nil {
 		return nil, err
 	}
@@ -182,7 +186,7 @@ func CreateTask(taskName string, param interface{}) (*Task, error) {
 	task := &Task{
 		TaskName:   taskName,
 		Parameter:  serializedParameter,
-		Serializer: serializer.GlobalSerializer,
+		Serializer: serializerType,
 		CurrentTry: 0,
 		// Default is don't retry
 		MaxRetry: defaultMaxRetry,

--- a/taskor.go
+++ b/taskor.go
@@ -26,10 +26,12 @@ type TaskManager interface {
 
 // New create a new Taskor instance
 func New(runner runner.Runner) (TaskManager, error) {
+	return NewWithSerializer(runner, serializer.TypeJSON)
+}
+
+func NewWithSerializer(runner runner.Runner, serializerType serializer.Type) (TaskManager, error) {
 	log.Debug("Starting")
-	serializer.GlobalSerializer = serializer.TypeJSON
-	taskor, err := handler.New(runner)
-	return taskor, err
+	return handler.NewWithSerializer(runner, serializerType)
 }
 
 // SetLogger - change current logger


### PR DESCRIPTION
Hello,

For some use cases, the only JSON serializer available in Taskor is not enough.

This PR aims to add a new serializer using [gob](https://pkg.go.dev/encoding/gob), the default binary encoding in Go.

It solves #23, and we're now able to serialize parameters having interfaces by using the gob serializer (see unit tests).

I've kept the JSON serializer as a default for backward compatibility.