### PR TITLE
feat(task): add task error field

### DIFF
--- a/handler/worker.go
+++ b/handler/worker.go
@@ -268,6 +268,7 @@ func (t *Taskor) execTask(currentTask *task.Task) (err error) {
 		// Handle panic in task execution, in case of panic the task is considered as in error
 		if r := recover(); r != nil {
 			currentTask.Error = fmt.Sprint(r)
+			currentTask.TaskError = task.NewError(fmt.Sprint(r))
 			err = errors.New(fmt.Sprint(r))
 			currentTask.DateDone = time.Now()
 		}
@@ -281,6 +282,12 @@ func (t *Taskor) execTask(currentTask *task.Task) (err error) {
 	if err != nil {
 		// Add error msg
 		currentTask.Error = err.Error()
+		switch err := err.(type) {
+		case *task.Error:
+			currentTask.TaskError = err
+		default:
+			currentTask.TaskError = task.NewError(err.Error())
+		}
 	}
 
 	// After task execution

--- a/task/error.go
+++ b/task/error.go
@@ -10,3 +10,41 @@ var (
 	// ErrNotRegisterd task has been pooled but was unknow (not register)
 	ErrNotRegisterd = errors.New("Task was pooled but was not register")
 )
+
+// Error represent Task error
+type Error struct {
+	// Message error message
+	Message string
+	// Metadata context of error
+	Metadata map[string]interface{}
+}
+
+// Error return Message of Error type
+func (e *Error) Error() string {
+	return e.Message
+}
+
+// ErrorOption implement option pattern
+type ErrorOption func(taskErr *Error)
+
+// WithMetadata enrich task error with metadata
+func WithMetadata(metadata map[string]string) ErrorOption {
+	return func(taskErr *Error) {
+		md := make(map[string]interface{})
+		for mdKey, mdValue := range metadata {
+			md[mdKey] = mdValue
+		}
+		taskErr.Metadata = md
+	}
+}
+
+// NewError initialize task.Error struct
+func NewError(message string, errOpts ...ErrorOption) *Error {
+	taskErr := &Error{Message: message}
+
+	for _, errOpt := range errOpts {
+		errOpt(taskErr)
+	}
+
+	return taskErr
+}

--- a/task/error_test.go
+++ b/task/error_test.go
@@ -1,0 +1,32 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewError(t *testing.T) {
+	message := "error message"
+	metadata := map[string]string{
+		"foo": "bar",
+		"one": "two",
+	}
+
+	t.Run("WithoutOptions", func(t *testing.T) {
+		expected := &Error{Message: "error message"}
+
+		err := NewError(message)
+		assert.Equal(t, expected, err)
+	})
+
+	t.Run("WithMetadata", func(t *testing.T) {
+		expected := &Error{Message: "error message", Metadata: map[string]interface{}{
+			"foo": "bar",
+			"one": "two",
+		}}
+
+		err := NewError(message, WithMetadata(metadata))
+		assert.Equal(t, expected, err)
+	})
+}

--- a/task/task.go
+++ b/task/task.go
@@ -73,7 +73,10 @@ type Task struct {
 	// ETA time after the task can be exec
 	ETA time.Time
 	// Error last error that was return by the task
+	// Deprecated: use TaskError instead
 	Error string
+	// TaskError error returned by task
+	TaskError *Error
 	// LinkError task
 	LinkError *Task
 	// ChildTasks Task
@@ -112,6 +115,8 @@ func (t *Task) UnmarshalJSON(b []byte) error {
 		ETA time.Time
 		// Error last error that was return by the task
 		Error string
+		// TaskError error returned by task
+		TaskError *Error
 		// LinkError task
 		LinkError *Task
 		// ChildTasks Task
@@ -143,6 +148,7 @@ func (t *Task) UnmarshalJSON(b []byte) error {
 	t.RetryOnError = unmarshallTmpObject.RetryOnError
 	t.ETA = unmarshallTmpObject.ETA
 	t.Error = unmarshallTmpObject.Error
+	t.TaskError = unmarshallTmpObject.TaskError
 	t.LinkError = unmarshallTmpObject.LinkError
 	t.ChildTasks = unmarshallTmpObject.ChildTasks
 	t.ParentTask = unmarshallTmpObject.ParentTask


### PR DESCRIPTION
This permit to implement a custom task error TaskError to easily add some new fields to enrich error.