### PR TITLE
feat:  add runner healthcheck + bump amqp dependency 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.18
 require (
 	github.com/golang/mock v1.6.0
 	github.com/jpillora/backoff v1.0.0
+	github.com/rabbitmq/amqp091-go v1.10.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/streadway/amqp v1.0.0
 	github.com/stretchr/testify v1.2.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,13 +6,14 @@ github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2E
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
+github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
-github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/handler/worker.go
+++ b/handler/worker.go
@@ -84,6 +84,11 @@ func (t *Taskor) RunWorker() error {
 	return nil
 }
 
+// IsRunnerHealthy checks that the runner connection and channel are set
+func (t *Taskor) IsRunnerHealthy() error {
+	return t.runner.IsHealthy()
+}
+
 // StopWorker stop all goroutine and runner worker
 func (t *Taskor) StopWorker() {
 	t.workerStopMutex.Lock()

--- a/handler/worker.go
+++ b/handler/worker.go
@@ -84,9 +84,9 @@ func (t *Taskor) RunWorker() error {
 	return nil
 }
 
-// IsRunnerHealthy checks that the runner connection and channel are set
-func (t *Taskor) IsRunnerHealthy() error {
-	return t.runner.IsHealthy()
+// IsRunnerReady checks that the runner is ready
+func (t *Taskor) IsRunnerReady() error {
+	return t.runner.IsReady()
 }
 
 // StopWorker stop all goroutine and runner worker

--- a/mock/taskor_mock.go
+++ b/mock/taskor_mock.go
@@ -77,18 +77,18 @@ func (mr *MockTaskManagerMockRecorder) Handle(Definition interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockTaskManager)(nil).Handle), Definition)
 }
 
-// IsRunnerHealthy mocks base method.
-func (m *MockTaskManager) IsRunnerHealthy() error {
+// IsRunnerReady mocks base method.
+func (m *MockTaskManager) IsRunnerReady() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsRunnerHealthy")
+	ret := m.ctrl.Call(m, "IsRunnerReady")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// IsRunnerHealthy indicates an expected call of IsRunnerHealthy.
-func (mr *MockTaskManagerMockRecorder) IsRunnerHealthy() *gomock.Call {
+// IsRunnerReady indicates an expected call of IsRunnerReady.
+func (mr *MockTaskManagerMockRecorder) IsRunnerReady() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunnerHealthy", reflect.TypeOf((*MockTaskManager)(nil).IsRunnerHealthy))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunnerReady", reflect.TypeOf((*MockTaskManager)(nil).IsRunnerReady))
 }
 
 // RunWorker mocks base method.

--- a/mock/taskor_mock.go
+++ b/mock/taskor_mock.go
@@ -5,64 +5,37 @@
 package mock_taskor
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	handler "github.com/scaleway/taskor/handler"
 	task "github.com/scaleway/taskor/task"
-	reflect "reflect"
 )
 
-// MockTaskManager is a mock of TaskManager interface
+// MockTaskManager is a mock of TaskManager interface.
 type MockTaskManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockTaskManagerMockRecorder
 }
 
-// MockTaskManagerMockRecorder is the mock recorder for MockTaskManager
+// MockTaskManagerMockRecorder is the mock recorder for MockTaskManager.
 type MockTaskManagerMockRecorder struct {
 	mock *MockTaskManager
 }
 
-// NewMockTaskManager creates a new mock instance
+// NewMockTaskManager creates a new mock instance.
 func NewMockTaskManager(ctrl *gomock.Controller) *MockTaskManager {
 	mock := &MockTaskManager{ctrl: ctrl}
 	mock.recorder = &MockTaskManagerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockTaskManager) EXPECT() *MockTaskManagerMockRecorder {
 	return m.recorder
 }
 
-// Send mocks base method
-func (m *MockTaskManager) Send(task *task.Task) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Send", task)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Send indicates an expected call of Send
-func (mr *MockTaskManagerMockRecorder) Send(task interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockTaskManager)(nil).Send), task)
-}
-
-// Handle mocks base method
-func (m *MockTaskManager) Handle(Definition *task.Definition) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Handle", Definition)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Handle indicates an expected call of Handle
-func (mr *MockTaskManagerMockRecorder) Handle(Definition interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockTaskManager)(nil).Handle), Definition)
-}
-
-// GetHandled mocks base method
+// GetHandled mocks base method.
 func (m *MockTaskManager) GetHandled() []*task.Definition {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHandled")
@@ -70,39 +43,13 @@ func (m *MockTaskManager) GetHandled() []*task.Definition {
 	return ret0
 }
 
-// GetHandled indicates an expected call of GetHandled
+// GetHandled indicates an expected call of GetHandled.
 func (mr *MockTaskManagerMockRecorder) GetHandled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHandled", reflect.TypeOf((*MockTaskManager)(nil).GetHandled))
 }
 
-// RunWorker mocks base method
-func (m *MockTaskManager) RunWorker() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunWorker")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RunWorker indicates an expected call of RunWorker
-func (mr *MockTaskManagerMockRecorder) RunWorker() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorker", reflect.TypeOf((*MockTaskManager)(nil).RunWorker))
-}
-
-// StopWorker mocks base method
-func (m *MockTaskManager) StopWorker() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "StopWorker")
-}
-
-// StopWorker indicates an expected call of StopWorker
-func (mr *MockTaskManagerMockRecorder) StopWorker() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWorker", reflect.TypeOf((*MockTaskManager)(nil).StopWorker))
-}
-
-// GetMetrics mocks base method
+// GetMetrics mocks base method.
 func (m *MockTaskManager) GetMetrics() handler.Metric {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetrics")
@@ -110,8 +57,76 @@ func (m *MockTaskManager) GetMetrics() handler.Metric {
 	return ret0
 }
 
-// GetMetrics indicates an expected call of GetMetrics
+// GetMetrics indicates an expected call of GetMetrics.
 func (mr *MockTaskManagerMockRecorder) GetMetrics() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetrics", reflect.TypeOf((*MockTaskManager)(nil).GetMetrics))
+}
+
+// Handle mocks base method.
+func (m *MockTaskManager) Handle(Definition *task.Definition) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Handle", Definition)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Handle indicates an expected call of Handle.
+func (mr *MockTaskManagerMockRecorder) Handle(Definition interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockTaskManager)(nil).Handle), Definition)
+}
+
+// IsRunnerHealthy mocks base method.
+func (m *MockTaskManager) IsRunnerHealthy() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsRunnerHealthy")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsRunnerHealthy indicates an expected call of IsRunnerHealthy.
+func (mr *MockTaskManagerMockRecorder) IsRunnerHealthy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsRunnerHealthy", reflect.TypeOf((*MockTaskManager)(nil).IsRunnerHealthy))
+}
+
+// RunWorker mocks base method.
+func (m *MockTaskManager) RunWorker() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunWorker")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunWorker indicates an expected call of RunWorker.
+func (mr *MockTaskManagerMockRecorder) RunWorker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorker", reflect.TypeOf((*MockTaskManager)(nil).RunWorker))
+}
+
+// Send mocks base method.
+func (m *MockTaskManager) Send(task *task.Task) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Send", task)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Send indicates an expected call of Send.
+func (mr *MockTaskManagerMockRecorder) Send(task interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockTaskManager)(nil).Send), task)
+}
+
+// StopWorker mocks base method.
+func (m *MockTaskManager) StopWorker() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopWorker")
+}
+
+// StopWorker indicates an expected call of StopWorker.
+func (mr *MockTaskManagerMockRecorder) StopWorker() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopWorker", reflect.TypeOf((*MockTaskManager)(nil).StopWorker))
 }

--- a/runner/amqp/amqp.go
+++ b/runner/amqp/amqp.go
@@ -95,8 +95,8 @@ func (t *RunnerAmqp) Stop() error {
 	return nil
 }
 
-// IsHealthy checks that the runner connection and channel are set
-func (t *RunnerAmqp) IsHealthy() error {
+// IsReady checks that the runner connection and channel are set
+func (t *RunnerAmqp) IsReady() error {
 	if t.conn == nil {
 		return fmt.Errorf("connection is not established")
 	}

--- a/runner/amqp/amqp.go
+++ b/runner/amqp/amqp.go
@@ -95,6 +95,24 @@ func (t *RunnerAmqp) Stop() error {
 	return nil
 }
 
+// IsHealthy checks that the runner connection and channel are set
+func (t *RunnerAmqp) IsHealthy() error {
+	if t.conn == nil {
+		return fmt.Errorf("connection is not established")
+	}
+	if t.conn.IsClosed() {
+		return fmt.Errorf("connection is closed")
+	}
+	if t.channel == nil {
+		return fmt.Errorf("channel is not established")
+	}
+	if t.channel.IsClosed() {
+		return fmt.Errorf("channel is closed")
+	}
+
+	return nil
+}
+
 func (t *RunnerAmqp) amqpConnect() error {
 	log.Info("Connection to RabbitMQ")
 	var err error

--- a/runner/amqp/amqp.go
+++ b/runner/amqp/amqp.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/scaleway/taskor/log"
 	"github.com/scaleway/taskor/serializer"
-	"github.com/streadway/amqp"
 )
 
 // Time to wait before retry after queue error

--- a/runner/amqp/consumer.go
+++ b/runner/amqp/consumer.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"time"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/scaleway/taskor/log"
 	"github.com/scaleway/taskor/serializer"
 	"github.com/scaleway/taskor/task"
-	"github.com/streadway/amqp"
 )
 
 func (t *RunnerAmqp) createConsumer() <-chan amqp.Delivery {

--- a/runner/amqp/publisher.go
+++ b/runner/amqp/publisher.go
@@ -3,9 +3,9 @@ package amqp
 import (
 	"errors"
 
+	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/scaleway/taskor/serializer"
 	"github.com/scaleway/taskor/task"
-	"github.com/streadway/amqp"
 )
 
 // Send send a new task in queue

--- a/runner/goroutine/goroutine.go
+++ b/runner/goroutine/goroutine.go
@@ -42,9 +42,8 @@ func (g *Runner) Stop() error {
 	return nil
 }
 
-// IsReady checks that the runner is ready
+// IsReady will always return nil for goroutine runner
 func (g *Runner) IsReady() error {
-	log.Warn("Method not implemented")
 	return nil
 }
 

--- a/runner/goroutine/goroutine.go
+++ b/runner/goroutine/goroutine.go
@@ -42,6 +42,12 @@ func (g *Runner) Stop() error {
 	return nil
 }
 
+// IsReady checks that the runner is ready
+func (g *Runner) IsReady() error {
+	log.Warn("Method not implemented")
+	return nil
+}
+
 // Send send a new task to the pool
 func (g *Runner) Send(t *task.Task) error {
 	g.internalChanTaskToRun <- *t

--- a/runner/mock/runner.go
+++ b/runner/mock/runner.go
@@ -62,18 +62,18 @@ func (mr *MockRunnerMockRecorder) Init() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockRunner)(nil).Init))
 }
 
-// IsHealthy mocks base method.
-func (m *MockRunner) IsHealthy() error {
+// IsReady mocks base method.
+func (m *MockRunner) IsReady() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsHealthy")
+	ret := m.ctrl.Call(m, "IsReady")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// IsHealthy indicates an expected call of IsHealthy.
-func (mr *MockRunnerMockRecorder) IsHealthy() *gomock.Call {
+// IsReady indicates an expected call of IsReady.
+func (mr *MockRunnerMockRecorder) IsReady() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHealthy", reflect.TypeOf((*MockRunner)(nil).IsHealthy))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsReady", reflect.TypeOf((*MockRunner)(nil).IsReady))
 }
 
 // RunWorkerTaskAck mocks base method.

--- a/runner/mock/runner.go
+++ b/runner/mock/runner.go
@@ -5,35 +5,36 @@
 package mock
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	task "github.com/scaleway/taskor/task"
-	reflect "reflect"
 )
 
-// MockRunner is a mock of Runner interface
+// MockRunner is a mock of Runner interface.
 type MockRunner struct {
 	ctrl     *gomock.Controller
 	recorder *MockRunnerMockRecorder
 }
 
-// MockRunnerMockRecorder is the mock recorder for MockRunner
+// MockRunnerMockRecorder is the mock recorder for MockRunner.
 type MockRunnerMockRecorder struct {
 	mock *MockRunner
 }
 
-// NewMockRunner creates a new mock instance
+// NewMockRunner creates a new mock instance.
 func NewMockRunner(ctrl *gomock.Controller) *MockRunner {
 	mock := &MockRunner{ctrl: ctrl}
 	mock.recorder = &MockRunnerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRunner) EXPECT() *MockRunnerMockRecorder {
 	return m.recorder
 }
 
-// GetConcurrency mocks base method
+// GetConcurrency mocks base method.
 func (m *MockRunner) GetConcurrency() int {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConcurrency")
@@ -41,13 +42,13 @@ func (m *MockRunner) GetConcurrency() int {
 	return ret0
 }
 
-// GetConcurrency indicates an expected call of GetConcurrency
+// GetConcurrency indicates an expected call of GetConcurrency.
 func (mr *MockRunnerMockRecorder) GetConcurrency() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConcurrency", reflect.TypeOf((*MockRunner)(nil).GetConcurrency))
 }
 
-// Init mocks base method
+// Init mocks base method.
 func (m *MockRunner) Init() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Init")
@@ -55,25 +56,39 @@ func (m *MockRunner) Init() error {
 	return ret0
 }
 
-// Init indicates an expected call of Init
+// Init indicates an expected call of Init.
 func (mr *MockRunnerMockRecorder) Init() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockRunner)(nil).Init))
 }
 
-// RunWorkerTaskAck mocks base method
+// IsHealthy mocks base method.
+func (m *MockRunner) IsHealthy() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsHealthy")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// IsHealthy indicates an expected call of IsHealthy.
+func (mr *MockRunnerMockRecorder) IsHealthy() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsHealthy", reflect.TypeOf((*MockRunner)(nil).IsHealthy))
+}
+
+// RunWorkerTaskAck mocks base method.
 func (m *MockRunner) RunWorkerTaskAck(arg0 <-chan task.Task) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RunWorkerTaskAck", arg0)
 }
 
-// RunWorkerTaskAck indicates an expected call of RunWorkerTaskAck
+// RunWorkerTaskAck indicates an expected call of RunWorkerTaskAck.
 func (mr *MockRunnerMockRecorder) RunWorkerTaskAck(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorkerTaskAck", reflect.TypeOf((*MockRunner)(nil).RunWorkerTaskAck), arg0)
 }
 
-// RunWorkerTaskProvider mocks base method
+// RunWorkerTaskProvider mocks base method.
 func (m *MockRunner) RunWorkerTaskProvider(arg0 chan task.Task, arg1 <-chan bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunWorkerTaskProvider", arg0, arg1)
@@ -81,13 +96,13 @@ func (m *MockRunner) RunWorkerTaskProvider(arg0 chan task.Task, arg1 <-chan bool
 	return ret0
 }
 
-// RunWorkerTaskProvider indicates an expected call of RunWorkerTaskProvider
+// RunWorkerTaskProvider indicates an expected call of RunWorkerTaskProvider.
 func (mr *MockRunnerMockRecorder) RunWorkerTaskProvider(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunWorkerTaskProvider", reflect.TypeOf((*MockRunner)(nil).RunWorkerTaskProvider), arg0, arg1)
 }
 
-// Send mocks base method
+// Send mocks base method.
 func (m *MockRunner) Send(arg0 *task.Task) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Send", arg0)
@@ -95,13 +110,13 @@ func (m *MockRunner) Send(arg0 *task.Task) error {
 	return ret0
 }
 
-// Send indicates an expected call of Send
+// Send indicates an expected call of Send.
 func (mr *MockRunnerMockRecorder) Send(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Send", reflect.TypeOf((*MockRunner)(nil).Send), arg0)
 }
 
-// Stop mocks base method
+// Stop mocks base method.
 func (m *MockRunner) Stop() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop")
@@ -109,7 +124,7 @@ func (m *MockRunner) Stop() error {
 	return ret0
 }
 
-// Stop indicates an expected call of Stop
+// Stop indicates an expected call of Stop.
 func (mr *MockRunnerMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockRunner)(nil).Stop))

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -18,4 +18,6 @@ type Runner interface {
 	RunWorkerTaskAck(taskDone <-chan task.Task)
 	// GetConcurrency return concurrency (max number of workers) configured for runner (allows parallel task processing)
 	GetConcurrency() int
+	// IsHealthy checks that the runner connection and channel are set
+	IsHealthy() error
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -18,6 +18,6 @@ type Runner interface {
 	RunWorkerTaskAck(taskDone <-chan task.Task)
 	// GetConcurrency return concurrency (max number of workers) configured for runner (allows parallel task processing)
 	GetConcurrency() int
-	// IsHealthy checks that the runner connection and channel are set
-	IsHealthy() error
+	// IsReady checks that the runner is ready
+	IsReady() error
 }

--- a/taskor.go
+++ b/taskor.go
@@ -22,8 +22,8 @@ type TaskManager interface {
 	StopWorker()
 	// GetMetrics return current metric
 	GetMetrics() handler.Metric
-	// IsRunnerHealthy checks that the runner connection and channel are set
-	IsRunnerHealthy() error
+	// IsRunnerReady checks that the runner connection and channel are set
+	IsRunnerReady() error
 }
 
 // New create a new Taskor instance

--- a/taskor.go
+++ b/taskor.go
@@ -22,6 +22,8 @@ type TaskManager interface {
 	StopWorker()
 	// GetMetrics return current metric
 	GetMetrics() handler.Metric
+	// IsRunnerHealthy checks that the runner connection and channel are set
+	IsRunnerHealthy() error
 }
 
 // New create a new Taskor instance


### PR DESCRIPTION
Hello

In this PR, we add a method `IsRunnerHealthy` which is useful for liveness probe and/or readiness probe. 

Also, the package `github.com/streadway/amqp` was changed to use `github.com/rabbitmq/amqp091-go` because this is the maintained package (see https://github.com/streadway/amqp?tab=readme-ov-file#beware-of-abandonware for more info). This is necessary because the method `t.channel.IsClosed()` is not available in `github.com/streadway/amqp` package.